### PR TITLE
Fix compilation with latest toolchain changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OC=arm-none-eabi-objcopy
 LD=arm-none-eabi-ld
 AM=armips
 
-CFLAGS=-std=gnu11 -Os -g -mword-relocations -fomit-frame-pointer -ffast-math -fshort-wchar -Wall -Wextra -Wpedantic -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wredundant-decls -Wshadow -Wsign-conversion -Wstrict-overflow=5 -Wswitch-default -Wundef -Wno-unused
+CFLAGS=-std=gnu11 -Os -g -mword-relocations -fomit-frame-pointer -ffast-math -fshort-wchar -Wall -Wextra -Wpedantic -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wredundant-decls -Wshadow -Wsign-conversion -Wstrict-overflow=5 -Wswitch-default -Wundef -Wno-unused -fno-tree-loop-distribute-patterns
 C9FLAGS=-mcpu=arm946e-s -march=armv5te -mlittle-endian
 C11FLAGS=-mcpu=mpcore -mlittle-endian
 LDFLAGS=

--- a/arm11/IFile.11.h
+++ b/arm11/IFile.11.h
@@ -17,10 +17,10 @@ typedef int (*IFile_Close_f)(IFILE *f);
 typedef int (*IFile_Read_f)(IFILE *f, unsigned int *read, void *buffer, unsigned int size);
 typedef int (*IFile_Write_f)(IFILE *f, uint32_t *written, void *src, uint32_t size);
 
-const IFile_Open_f IFile_Open;
-const IFile_Close_f IFile_Close;
-const IFile_Read_f IFile_Read;
-const IFile_Write_f IFile_Write;
+extern const IFile_Open_f IFile_Open;
+extern const IFile_Close_f IFile_Close;
+extern const IFile_Read_f IFile_Read;
+extern const IFile_Write_f IFile_Write;
 
 #endif//IFILE_11_H_
 


### PR DESCRIPTION
- Mark IFile11 functions as extern
- Add -fno-tree-loop-distribute-patterns to avoid compiler optimizing to memset when stdlib not present